### PR TITLE
only switch to black colors once

### DIFF
--- a/BlochBuster.py
+++ b/BlochBuster.py
@@ -1285,7 +1285,7 @@ def run(configFile, leapFactor=1):
     ### Setup config correctly ###
     checkConfig(config)
 
-    if config['background']['color'] == 'black':
+    if config['background']['color'] == 'black' and colors['bg'][0] == 1:
         for i in ['bg', 'axis', 'text', 'circle']:
             colors[i][:3] = list(map(lambda x: 1-x, colors[i][:3]))
 


### PR DESCRIPTION
# Dear Ass. Prof #
I've noticed that the black background color flips between subsequent runs of BlochBuster:


```
#!/usr/bin/env python3

import BlochBuster
BlochBuster.run(r'config/SE.yml') # Black bg is desired so colors are inverted
BlochBuster.run(r'config/FSE.yml') # Black bg is desired so colors are inverted again, resulting in white bg
```


I've resolved this busted BlochBuster issue by checking if the background is indeed white before inverting it.