### PR TITLE
canvas.tostring_rgb is depicated after mplib 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/bretglun/BlochBuster"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
 scipy = "^1.9.3"
-matplotlib = "^3.7.3"
+matplotlib = "^3.7.3,<=3.8"
 PyYAML = "^6.0.1"
 ffmpeg-python = "^0.2.0"
 static-ffmpeg = "^2.5"


### PR DESCRIPTION
After Downgrading to matplotlib 3.8.0 does everything work again. 

Source:
https://github.com/CASIA-IVA-Lab/FastSAM/issues/227